### PR TITLE
[FIX] inconsistent slice timing throw errors and not warnings

### DIFF
--- a/src/bids/getAndCheckSliceOrder.m
+++ b/src/bids/getAndCheckSliceOrder.m
@@ -57,10 +57,11 @@ function sliceOrder = getAndCheckSliceOrder(BIDS, opt, filter)
 
     sliceOrder = [];
 
-    msg = sprintf('inconsistent slice timing found for filter:\n%s.\n\n', ...
+    msg = sprintf(['Inconsistent slice timing found for filter:\n%s.\n\n', ...
+                   'Number of slice per volume seems different across bold files.'], ...
                   bids.internal.create_unordered_list(filter));
-    id = 'inconsistentSliceTiming';
-    logger('WARNING', msg, 'id', id, 'filename', mfilename(), 'options', opt);
+    id = 'inconsistentSliceTimingLength';
+    logger('ERROR', msg, 'id', id, 'filename', mfilename(), 'options', opt);
 
     return
 
@@ -76,9 +77,9 @@ function sliceOrder = getAndCheckSliceOrder(BIDS, opt, filter)
 
       sliceOrder = [];
 
-      wng = sprintf('inconsistent slice timing found for filter:\n%s.\n\n', ...
+      msg = sprintf('Inconsistent slice timing found for filter:\n%s.\n\n', ...
                     bids.internal.create_unordered_list(filter));
-      id = 'inconsistentSliceTiming';
+      id = 'inconsistentSliceTimingValues';
       logger('WARNING', msg, 'id', id, 'filename', mfilename(), 'options', opt);
 
       return

--- a/tests/tests_bids/unit_tests/test_getAndCheckSliceOrder.m
+++ b/tests/tests_bids/unit_tests/test_getAndCheckSliceOrder.m
@@ -38,9 +38,8 @@ function test_getAndCheckSliceOrder_inconsistent_slice_timing()
 
   [BIDS, opt, filter] = setUp({'vismotion', 'vislocalizer'});
 
-  sliceOrder = getAndCheckSliceOrder(BIDS, opt, filter);
-
-  assert(isempty(sliceOrder));
+  assertExceptionThrown(@()getAndCheckSliceOrder(BIDS, opt, filter), ...
+                        'getAndCheckSliceOrder:inconsistentSliceTimingLength');
 
 end
 


### PR DESCRIPTION
relates to #967

Rather than returning empty (and thus leading to skip slice timing) when slice timing values are inconsistent, `getAndCheckSliceOrder` will now throw an error.