### PR TITLE
[FIX] Force copy of data from fmriprep folder even if bidspm-preproc folder exists

### DIFF
--- a/bidspm.m
+++ b/bidspm.m
@@ -268,9 +268,7 @@ function smooth(args)
 
   saveOptions(opt);
 
-  if ~isdir(opt.dir.output)
-    copy(args);
-  end
+  copy(args);
 
   if opt.fwhm.func > 0
     opt.query.desc = 'preproc';


### PR DESCRIPTION
See #1006