### PR TITLE
[FIX] less warnings in bids model

### DIFF
--- a/src/bids_model/BidsModel.m
+++ b/src/bids_model/BidsModel.m
@@ -103,7 +103,12 @@ classdef BidsModel < bids.Model
                       spm_get_defaults('stats.fmri.hpf'), ...
                       nodeName, ...
                       returnBsmDocURL('options'));
-        obj.bidsModelError('noHighPassFilter', msg);
+
+        opt.verbosity = 0;
+        if obj.verbose
+          opt.verbosity = 1;
+        end
+        logger('INFO', msg, 'filename', mfilename(), 'options', opt);
 
       else
 
@@ -151,7 +156,12 @@ classdef BidsModel < bids.Model
                       nodeName, ...
                       nodeName, ...
                       returnRtdURL('', 'HRF'));
-        obj.bidsModelError('noHRFderivatives', msg);
+
+        opt.verbosity = 0;
+        if obj.verbose
+          opt.verbosity = 1;
+        end
+        logger('INFO', msg, 'filename', mfilename(), 'options', opt);
       end
 
       HRFderivatives = lower(strrep(HRFderivatives, ' ', ''));
@@ -196,7 +206,12 @@ classdef BidsModel < bids.Model
                       nodeName, ...
                       nodeName, ...
                       returnBsmDocURL('options'));
-        obj.bidsModelError('noMask', msg);
+
+        opt.verbosity = 0;
+        if obj.verbose
+          opt.verbosity = 1;
+        end
+        logger('INFO', msg, 'filename', mfilename(), 'options', opt);
 
       end
 
@@ -241,7 +256,12 @@ classdef BidsModel < bids.Model
                       spm_get_defaults('mask.thresh'), ...
                       nodeName, ...
                       returnRtdURL('', 'software'));
-        obj.bidsModelError('noInclMaskThresh', msg);
+
+        opt.verbosity = 0;
+        if obj.verbose
+          opt.verbosity = 1;
+        end
+        logger('INFO', msg, 'filename', mfilename(), 'options', opt);
 
       end
 
@@ -280,7 +300,11 @@ classdef BidsModel < bids.Model
                       nodeName, ...
                       returnRtdURL('', 'software'));
 
-        obj.bidsModelError('noTemporalCorrection', msg);
+        opt.verbosity = 0;
+        if obj.verbose
+          opt.verbosity = 1;
+        end
+        logger('INFO', msg, 'filename', mfilename(), 'options', opt);
 
       end
 

--- a/tests/tests_bids_model/test_bidsModel.m
+++ b/tests/tests_bids_model/test_bidsModel.m
@@ -198,14 +198,6 @@ function test_getModelMask_method()
   mask = bm.getModelMask('Name', 'run_level');
   assertEqual(mask, 'mask.nii');
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
-  bm.verbose = true;
-  bm.Nodes{1}.Model.Options = rmfield(bm.Nodes{1}.Model.Options, 'Mask');
-  assertWarning(@()bm.getModelMask('Name', 'run_level'), ...
-                'BidsModel:noMask');
-
 end
 
 function test_getInclusiveMaskThreshold()
@@ -240,12 +232,6 @@ function test_getInclusiveMaskThreshold_method()
   bm = BidsModel('file', opt.model.file, 'verbose', true);
 
   bm.getInclusiveMaskThreshold('Name', 'subject_level');
-
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
-  assertWarning(@()bm.getInclusiveMaskThreshold('Name', 'subject_level'), ...
-                'BidsModel:noInclMaskThresh');
 
 end
 


### PR DESCRIPTION
reduce number of warnings thrown by BidsModel to avoid confusing users and replace them by INFO logs instead

closes #1180 