### PR TITLE
[FIX] skip IC from MACS toolbox for octave for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [ENH] allow to copy anat only on raw datasets #1181 by @Remi-Gau
 * [ENH] add option to concatenate runs at subject level to facilite running PPI analysis #1133 by @Remi-Gau
 * [ENH] allow to run substeps of substeps of the bayesian model selection #1145 by @Remi-Gau
-* [ENH] add quality control for GLM using the MACS toolbox to give a goodness of fit several other information criteria (AIC, BIC) #1135  by @Remi-Gau
+* [ENH] add quality control for GLM using the MACS toolbox to give a goodness of fit and several other information criteria (AIC, BIC) (MATLAB only) #1135  by @Remi-Gau
 * [ENH] add several confound strategies to add to bids stats model and a function to create family of models #1126 by @Remi-Gau
 * [ENH] add CLI to run bayesian model selection #1121 by @Remi-Gau
 * [ENH] support label of activations with all atlases [1100](https://github.com/cpp-lln-lab/bidspm/pull/1100) by [Remi-Gau](https://github.com/Remi-Gau)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cpp-lln-lab/bidspm/main)
   [![tests matlab](https://github.com/cpp-lln-lab/bidspm/actions/workflows/tests.yml/badge.svg)](https://github.com/cpp-lln-lab/bidspm/actions/workflows/tests.yml)
   [![tests octave](https://github.com/cpp-lln-lab/bidspm/actions/workflows/tests_octave.yml/badge.svg)](https://github.com/cpp-lln-lab/bidspm/actions/workflows/tests_octave.yml)
-  [![codecov](https://codecov.io/gh/cpp-lln-lab/bidspm/branch/main/graph/badge.svg?token=PMQYH0DIPX)](https://codecov.io/gh/cpp-lln-lab/bidspm)
+  [![codecov](https://codecov.io/gh/cpp-lln-lab/bidspm/graph/badge.svg?token=PMQYH0DIPX)](https://codecov.io/gh/cpp-lln-lab/bidspm)
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3554331.svg)](https://doi.org/10.5281/zenodo.3554331)
   [![GitHub last commit](https://img.shields.io/github/last-commit/cpp-lln-lab/bidspm)](https://github.com/cpp-lln-lab/bidspm.git)
   [![All Contributors](https://img.shields.io/badge/all_contributors-14-orange.svg?style=flat-square)](https://github.com/cpp-lln-lab/bidspm#contributors)

--- a/demos/MoAE/moae_fmriprep.m
+++ b/demos/MoAE/moae_fmriprep.m
@@ -22,8 +22,8 @@ clc;
 addpath(fullfile(pwd, '..', '..'));
 bidspm();
 
-DOWNLOAD_DATA = false;
-SMOOTH = false;
+DOWNLOAD_DATA = true;
+SMOOTH = true;
 
 % Getting the raw dataset to get the events.tsv
 download_moae_ds(DOWNLOAD_DATA);

--- a/demos/MoAE/moae_fmriprep.m
+++ b/demos/MoAE/moae_fmriprep.m
@@ -22,8 +22,8 @@ clc;
 addpath(fullfile(pwd, '..', '..'));
 bidspm();
 
-DOWNLOAD_DATA = true;
-SMOOTH = true;
+DOWNLOAD_DATA = false;
+SMOOTH = false;
 
 % Getting the raw dataset to get the events.tsv
 download_moae_ds(DOWNLOAD_DATA);

--- a/src/IO/overwriteDir.m
+++ b/src/IO/overwriteDir.m
@@ -7,8 +7,10 @@ function overwriteDir(directory, opt)
 
   % (C) Copyright 2021 bidspm developers
 
+  directory = bids.internal.format_path(directory);
+
   if exist(directory, 'dir') == 7
-    msg = sprintf('\noverwriting directory:\n\t%s\n\n', bids.internal.format_path(directory));
+    msg = sprintf('\noverwriting directory:\n\t%s\n\n', directory);
     id = 'overWritingDir';
     logger('WARNING', msg, 'id', id, 'filename', mfilename(), 'options', opt);
     rmdir(directory, 's');

--- a/src/batches/stats/setBatchInformationCriteria.m
+++ b/src/batches/stats/setBatchInformationCriteria.m
@@ -1,6 +1,14 @@
 function matlabbatch = setBatchInformationCriteria(matlabbatch, opt, outputDir)
 
   % (C) Copyright 2023 bidspm developers
+
+  if bids.internal.is_octave()
+    notImplemented(mfilename(), ...
+                   'Information criterion not implemented in Octave.', ...
+                   opt);
+    return
+  end
+
   MA_model_space.dir = {outputDir};
   MA_model_space.models{1}{1}(1) = cfg_dep('Model estimation: SPM.mat File', ...
                                            returnDependency(opt, 'estimate'), ...

--- a/tests/tests_slow/tests_workflows/stats/test_bidsFFX.m
+++ b/tests/tests_slow/tests_workflows/stats/test_bidsFFX.m
@@ -48,7 +48,7 @@ function test_bidsFFX_individual()
 
     expectedNbBatch = 7;
     if bids.internal.is_octave()
-      expectedNbBatch = 6;
+      expectedNbBatch = 4;
     end
     % specify
     % print design matrix

--- a/tests/tests_slow/tests_workflows/stats/test_bidsRFX.m
+++ b/tests/tests_slow/tests_workflows/stats/test_bidsRFX.m
@@ -37,7 +37,7 @@ function test_bidsRFX_rfx()
   batchOrder = extendBatchOrder();
   idx = 9:6:(nbGroupLevelModels * nbBatchPerModel);
   if bids.internal.is_octave()
-    idx = 9:5:(nbGroupLevelModels * nbBatchPerModel);
+    idx = 9:4:(nbGroupLevelModels * nbBatchPerModel);
   end
   for i = idx
     assertEqual(summary([i:i + size(batchOrder, 1) - 1], :), batchOrder); %#ok<*NBRAK>
@@ -107,7 +107,7 @@ function test_bidsRFX_within_group_ttest()
               fileparts(matlabbatch{5}.spm.stats.fmri_est.spmmat{1}));
   if bids.internal.is_octave()
     assertEqual(matlabbatch{3}.spm.stats.factorial_design.dir{1}, ...
-                fileparts(matlabbatch{10}.spm.stats.fmri_est.spmmat{1}));
+                fileparts(matlabbatch{8}.spm.stats.fmri_est.spmmat{1}));
   else
     assertEqual(matlabbatch{3}.spm.stats.factorial_design.dir{1}, ...
                 fileparts(matlabbatch{11}.spm.stats.fmri_est.spmmat{1}));

--- a/tests/tests_slow/tests_workflows/stats/test_bidsRFX.m
+++ b/tests/tests_slow/tests_workflows/stats/test_bidsRFX.m
@@ -37,7 +37,7 @@ function test_bidsRFX_rfx()
   batchOrder = extendBatchOrder();
   idx = 9:6:(nbGroupLevelModels * nbBatchPerModel);
   if bids.internal.is_octave()
-    idx = 9:4:(nbGroupLevelModels * nbBatchPerModel);
+    idx = 9:3:(nbGroupLevelModels * nbBatchPerModel);
   end
   for i = idx
     assertEqual(summary([i:i + size(batchOrder, 1) - 1], :), batchOrder); %#ok<*NBRAK>
@@ -193,7 +193,7 @@ function test_bidsRFX_several_datasets_level()
   nbGroupLevelModelsReturned = 1;
   nbBatchPerModel = 8;
   if bids.internal.is_octave()
-    nbBatchPerModel = 7;
+    nbBatchPerModel = 5;
   end
   assertEqual(numel(matlabbatch), nbGroupLevelModelsReturned * nbBatchPerModel);
 

--- a/tests/tests_slow/tests_workflows/stats/test_bidsRFX.m
+++ b/tests/tests_slow/tests_workflows/stats/test_bidsRFX.m
@@ -21,7 +21,7 @@ function test_bidsRFX_rfx()
   nbGroupLevelModels = 4;
   nbBatchPerModel = 8;
   if bids.internal.is_octave()
-    nbBatchPerModel = 7;
+    nbBatchPerModel = 5;
   end
   assertEqual(numel(matlabbatch), nbGroupLevelModels * nbBatchPerModel);
 
@@ -59,7 +59,7 @@ function test_bidsRFX_no_overwrite_smoke_test()
 
   expectedNbBatch = 8;
   if bids.internal.is_octave()
-    expectedNbBatch = 7;
+    expectedNbBatch = 5;
   end
   assertEqual(numel(matlabbatch), expectedNbBatch);
 
@@ -78,7 +78,7 @@ function test_bidsRFX_within_group_ttest()
   matlabbatch = bidsRFX('RFX', opt);
 
   if bids.internal.is_octave()
-    assertEqual(numel(matlabbatch), 14);
+    assertEqual(numel(matlabbatch), 10);
   else
     assertEqual(numel(matlabbatch), 16);
   end
@@ -256,7 +256,7 @@ function batchOrder = extendBatchOrder(batchOrder)
                'stats', 'review'; ...
                'util', 'print'};
   if bids.internal.is_octave()
-    extension(2, :) = [];
+    extension(2:4, :) = [];
   end
   batchOrder = cat(1, batchOrder, extension);
 end


### PR DESCRIPTION
- should at least allow bidspm stats to octave on octave until things are fixed upstream