### PR TITLE
[MAINT] update octave install for ubuntu 24.04

### DIFF
--- a/.github/workflows/run_tests_cli.yml
+++ b/.github/workflows/run_tests_cli.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
     tests_cli:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         if: github.repository_owner == 'cpp-lln-lab'
         strategy:
             fail-fast: false
@@ -56,7 +56,7 @@ jobs:
         #         fail_ci_if_error: false
 
     boutiques:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         if: github.repository_owner == 'cpp-lln-lab'
         steps:
         -   name: Clone bidspm
@@ -81,6 +81,11 @@ jobs:
             run: |
                 python -m pip install --upgrade pip setuptools
                 pip install datalad
+
+        -   name: Post-install
+            run: |
+                git config --global --add user.name "Ford Escort"
+                git config --global --add user.email 42@H2G2.com
 
         -   name: Get data
             run: |

--- a/.github/workflows/run_tests_cli.yml
+++ b/.github/workflows/run_tests_cli.yml
@@ -22,7 +22,7 @@ jobs:
         -   name: Install dependencies
             run: |
                 sudo apt-get -y -qq update
-                sudo apt-get -y install octave liboctave-dev
+                sudo apt-get -y install octave octave-dev
         -   name: Info
             run: octave --version
         -   name: Install Deno
@@ -94,7 +94,7 @@ jobs:
                 sudo apt-get -y -qq update
                 sudo apt-get -y install \
                     octave \
-                    liboctave-dev\
+                    octave-dev\
                     octave-common \
                     octave-io \
                     octave-image \

--- a/.github/workflows/run_tests_notebooks.yml
+++ b/.github/workflows/run_tests_notebooks.yml
@@ -21,7 +21,7 @@ jobs:
     # only trigger update on upstream repo
         if: github.repository_owner == 'cpp-lln-lab'
 
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
 
         steps:
         -   name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,11 @@ jobs:
                 unzip download
                 mv moae_fmriprep fmriprep
 
+        -   name: Post-install
+            run: |
+                git config --global --add user.name "Ford Escort"
+                git config --global --add user.email 42@H2G2.com
+
         -   name: Get data for testing QA
             if: matrix.os == 'ubuntu-latest'
             run: |
@@ -174,6 +179,11 @@ jobs:
                 wget https://osf.io/vufjs/download
                 unzip download
                 mv moae_fmriprep fmriprep
+
+        -   name: Post-install
+            run: |
+                git config --global --add user.name "Ford Escort"
+                git config --global --add user.email 42@H2G2.com
 
         -   name: Get data for testing QA
             if: matrix.os == 'ubuntu-latest'
@@ -273,6 +283,11 @@ jobs:
                 wget https://osf.io/vufjs/download
                 unzip download
                 mv moae_fmriprep fmriprep
+
+        -   name: Post-install
+            run: |
+                git config --global --add user.name "Ford Escort"
+                git config --global --add user.email 42@H2G2.com
 
         -   name: Prepare test data unix
             run: |

--- a/.github/workflows/tests_octave.yml
+++ b/.github/workflows/tests_octave.yml
@@ -120,7 +120,7 @@ jobs:
                 sudo apt-get -y -qq update
                 sudo apt-get -y install \
                   octave \
-                  liboctave-dev\
+                  octave-dev\
                   octave-common \
                   octave-io \
                   octave-image \

--- a/.github/workflows/tests_octave.yml
+++ b/.github/workflows/tests_octave.yml
@@ -99,6 +99,11 @@ jobs:
                 unzip download
                 mv moae_fmriprep fmriprep
 
+        -   name: Post-install
+            run: |
+                git config --global --add user.name "Ford Escort"
+                git config --global --add user.email 42@H2G2.com
+
         -   name: Get data for testing QA
             run: |
                 cd demos/openneuro/


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Octave installation in CI workflows to use the `octave-dev` package.